### PR TITLE
Fix : The order of arguments in the newButton function is incorrect

### DIFF
--- a/com/ponywolf/vjoy.lua
+++ b/com/ponywolf/vjoy.lua
@@ -7,7 +7,7 @@
 local M = {}
 local stage = display.getCurrentStage()
 
-function M.newButton(radius, key)
+function M.newButton(key, radius)
 
   local instance
   radius = radius or 64


### PR DESCRIPTION
The order of arguments in the newButton function doesn't correspond to the documentation.